### PR TITLE
feat: add dynamic url job query/filtering

### DIFF
--- a/app/[jobFilter]/page.tsx
+++ b/app/[jobFilter]/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useTheme } from "../theme-context";
+import Header from "../components/header/header";
+import Banner from "../components/banner/banner";
+import Jobs from "../components/jobs/jobs";
+import Footer from "../components/footer/footer";
+import { PageType } from "../types/enums";
+
+const JobFilterPage: React.FC = () => {
+    const { isDarkTheme } = useTheme();
+    const searchParams = useSearchParams();
+    const [bannerTitle, setBannerTitle] = useState("AI Jobs");
+    const [tag, setTag] = useState<string | undefined>(undefined);
+    const [location, setLocation] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        const tagsParam = searchParams.get("tags") || "";
+        const locationsParam = searchParams.get("locations") || "";
+        const tags = tagsParam.split(",").filter(Boolean);
+        const locations = locationsParam.split(",").filter(Boolean);
+
+        if (tags.length > 0) {
+            setTag(tags[0]);
+            setBannerTitle(`AI ${tags[0]} Jobs`);
+        }
+
+        if (locations.length > 0) {
+            setLocation(locations[0]);
+            setBannerTitle((prev) => `${prev} in ${locations[0]}`);
+        }
+
+        if (tags.length === 0 && locations.length === 0) {
+            setBannerTitle("AI Jobs");
+        }
+    }, [searchParams]);
+
+    useEffect(() => {
+        const root = document.documentElement;
+        root.style.setProperty(
+            "--wrap-tx-color",
+            isDarkTheme ? "var(--dark-wrap-tx)" : "var(--light-wrap-tx)"
+        );
+        root.style.setProperty(
+            "--tx-color",
+            isDarkTheme ? "var(--dark-tx)" : "var(--light-tx)"
+        );
+        root.style.setProperty(
+            "--bg-color",
+            isDarkTheme ? "var(--dark-bg)" : "var(--light-bg)"
+        );
+        root.style.setProperty(
+            "--hl-color",
+            isDarkTheme ? "var(--dark-hl)" : "var(--light-hl)"
+        );
+    }, [isDarkTheme]);
+
+    return (
+        <div>
+            <Header />
+            <main>
+                <Banner type={PageType.FILTER} title={bannerTitle} />
+                <div className="mainContent">
+                    <Jobs tag={tag} location={location} />
+                </div>
+            </main>
+            <Footer />
+        </div>
+    );
+};
+
+export default JobFilterPage;

--- a/app/[jobFilter]/page.tsx
+++ b/app/[jobFilter]/page.tsx
@@ -2,15 +2,10 @@
 
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useTheme } from "../theme-context";
-import Header from "../components/header/header";
-import Banner from "../components/banner/banner";
-import Jobs from "../components/jobs/jobs";
-import Footer from "../components/footer/footer";
+import BaseLayout from "../components/base-layout";
 import { PageType } from "../types/enums";
 
 const JobFilterPage: React.FC = () => {
-    const { isDarkTheme } = useTheme();
     const searchParams = useSearchParams();
     const [bannerTitle, setBannerTitle] = useState("AI Jobs");
     const [tag, setTag] = useState<string | undefined>(undefined);
@@ -37,37 +32,13 @@ const JobFilterPage: React.FC = () => {
         }
     }, [searchParams]);
 
-    useEffect(() => {
-        const root = document.documentElement;
-        root.style.setProperty(
-            "--wrap-tx-color",
-            isDarkTheme ? "var(--dark-wrap-tx)" : "var(--light-wrap-tx)"
-        );
-        root.style.setProperty(
-            "--tx-color",
-            isDarkTheme ? "var(--dark-tx)" : "var(--light-tx)"
-        );
-        root.style.setProperty(
-            "--bg-color",
-            isDarkTheme ? "var(--dark-bg)" : "var(--light-bg)"
-        );
-        root.style.setProperty(
-            "--hl-color",
-            isDarkTheme ? "var(--dark-hl)" : "var(--light-hl)"
-        );
-    }, [isDarkTheme]);
-
     return (
-        <div>
-            <Header />
-            <main>
-                <Banner type={PageType.FILTER} title={bannerTitle} />
-                <div className="mainContent">
-                    <Jobs tag={tag} location={location} />
-                </div>
-            </main>
-            <Footer />
-        </div>
+        <BaseLayout
+            pageType={PageType.FILTER}
+            bannerTitle={bannerTitle}
+            tag={tag}
+            location={location}
+        />
     );
 };
 

--- a/app/components/banner/banner.tsx
+++ b/app/components/banner/banner.tsx
@@ -16,7 +16,7 @@ function Banner({ type, title }: BannerProps) {
     let bannerContent;
 
     switch (type) {
-        case PageType.CATEGORY:
+        case PageType.FILTER:
         default:
             bannerContent = (
                 <>

--- a/app/components/base-layout.tsx
+++ b/app/components/base-layout.tsx
@@ -2,14 +2,26 @@
 
 import { useEffect } from "react";
 import { useTheme } from "../theme-context";
-import Header from "../components/header/header";
-import Banner from "../components/banner/banner";
-import Jobs from "../components/jobs/jobs";
-import Footer from "../components/footer/footer";
+import Header from "./header/header";
+import Banner from "./banner/banner";
+import Jobs from "./jobs/jobs";
+import Footer from "./footer/footer";
 import { PageType } from "../types/enums";
 
-const Home: React.FC = () => {
-    const { isDarkTheme, toggleTheme } = useTheme();
+interface BaseLayoutProps {
+    pageType: PageType;
+    bannerTitle: string;
+    tag?: string;
+    location?: string;
+}
+
+const BaseLayout: React.FC<BaseLayoutProps> = ({
+    pageType,
+    bannerTitle,
+    tag,
+    location,
+}) => {
+    const { isDarkTheme } = useTheme();
 
     useEffect(() => {
         const root = document.documentElement;
@@ -33,11 +45,11 @@ const Home: React.FC = () => {
 
     return (
         <div>
-            <Header type={PageType.HOME} />
+            <Header type={pageType} />
             <main>
-                <Banner type={PageType.HOME} title="AI Jobs" />
+                <Banner type={pageType} title={bannerTitle} />
                 <div className="mainContent">
-                    <Jobs />
+                    <Jobs tag={tag} location={location} />
                 </div>
             </main>
             <Footer />
@@ -45,4 +57,4 @@ const Home: React.FC = () => {
     );
 };
 
-export default Home;
+export default BaseLayout;

--- a/app/components/filter/filter.tsx
+++ b/app/components/filter/filter.tsx
@@ -4,28 +4,38 @@ import { useState, useEffect } from "react";
 import SearchField from "./search-field";
 import styles from "./filter.module.css";
 import { useTheme } from "../../theme-context";
+import { useRouter } from "next/navigation";
 import {
     JobsTagsOptions,
     JobsCountryOptions,
 } from "../../types/pocketbase-types";
 
 interface FilterProps {
-    onFilterChange: (tags: { tags: string[]; locations: string[] }) => void;
+    onFilterChange: (filters: { tags: string[]; locations: string[] }) => void;
 }
 
 function Filter(props: FilterProps) {
     const { onFilterChange } = props;
     const { isDarkTheme } = useTheme();
-
+    const router = useRouter();
     const [selectedTags, setSelectedTags] = useState<any[]>([]);
     const [selectedLocation, setSelectedLocation] = useState<any[]>([]);
-
-    // Call the callback function whenever selectedOptions change
 
     useEffect(() => {
         const tags = selectedTags.map((option) => option.value);
         const locations = selectedLocation.map((option) => option.value);
         onFilterChange({ tags, locations });
+
+        if (tags.length === 0 && locations.length === 0) {
+            // Do not change URL if no filters are selected
+            return;
+        }
+
+        const tagsParam = encodeURIComponent(tags.join(","));
+        const locationsParam = encodeURIComponent(locations.join(","));
+        const query = `?tags=${tagsParam}&locations=${locationsParam}`;
+
+        router.push(`/jobs${query}`);
     }, [selectedTags, selectedLocation]);
 
     return (
@@ -50,7 +60,6 @@ function Filter(props: FilterProps) {
                     />
                 </div>
             </div>
-            {/* Selected Tags */}
             <div className={styles.filterSelectedTags}>
                 {selectedTags.map((option, index) => (
                     <div key={index} className={styles.filterSelectedTag}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
-import Home from "./home/page";
+import BaseLayout from "./components/base-layout";
+import { PageType } from "./types/enums";
 
-export default function Page() {
-    return <Home />;
-}
+const Home: React.FC = () => {
+    return <BaseLayout pageType={PageType.HOME} bannerTitle="AI Jobs" />;
+};
+
+export default Home;

--- a/app/types/enums.ts
+++ b/app/types/enums.ts
@@ -1,5 +1,5 @@
 export enum PageType {
     HOME, // Home page
     POST, // Post a job page
-    CATEGORY, // Specific job/location/company page
+    FILTER,
 }


### PR DESCRIPTION
Updates search tags and locations to dynamically generate a unique URL.

This means specific job posts can be found why filtering within the URL or by selecting the tag/location in seach bars.

As each page is unique, we update the banner h1 tag to specify the query in an SEO optimized manner. These h1 tags should align as close real search queries online.

---

Next steps: Combine the existing search fields into a single search box. Improve tag selecting and deselecting. Remove infinite scroll in favour page numbers. Add remote as a location. We also really need to start scraping again so we can get job listings without emojis.